### PR TITLE
Jasmine fail: should call the validate method when setting a property

### DIFF
--- a/public/js/test/specs/spec.js
+++ b/public/js/test/specs/spec.js
@@ -46,7 +46,7 @@ define(["jquery", "backbone", "marionette", "models/Model", "collections/Collect
                 });
 
                 it("should call the validate method when setting a property", function() {
-                    this.model.set({ example: "test" });
+                    this.model.set({ example: "test" }, { validate: true });
                     expect(Model.prototype.validate).toHaveBeenCalled();
                 });
 


### PR DESCRIPTION
The test on the model's validation function fails because validate isn't called unless save() is used, or if validate: true is passed as an option with set().

This test doesn't fail on your dev branch. I'm not sure why, to be honest!
